### PR TITLE
Upgrade to latest stable version of jasmine-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "node.packer": "2.0.0",
-    "jasmine-node": "1.5.0"
+    "jasmine-node": "1.7.1"
   }
 }


### PR DESCRIPTION
The version 1.0.26 is not compatible with latest stable version of node:

node_modules/jasmine-node/lib/jasmine-node/index.js:21
var minorVersion = process.version.match(/\d.(\d).\d/)[1];
                                                        ^
                                                        TypeError:
                                                        Cannot read property
                                                        '1' of null

This test fails with 'v0.10.5', where minor version has two digits.
