### PR TITLE
Replace tabs with spaces in advanced demo

### DIFF
--- a/demos/advanced/asteroid.js
+++ b/demos/advanced/asteroid.js
@@ -26,15 +26,15 @@
     zIndex: 0,
     destroyed: false,
 
-	  update: function() {
+    update: function() {
       if (this.game.state !== this.game.STATE.PLAYING) return;
-		  var mx = this.vel.x * this.game.coquette.updater.tick;
-		  var my = this.vel.y * this.game.coquette.updater.tick;
+      var mx = this.vel.x * this.game.coquette.updater.tick;
+      var my = this.vel.y * this.game.coquette.updater.tick;
       this.pos.x += mx;
       this.pos.y += my;
 
       this.wrap();
-	  },
+    },
 
     wrap: function() {
       if (this.game.maths.distance(this.game.maths.center(this), this.game.coquette.renderer.center()) >

--- a/demos/advanced/bullet.js
+++ b/demos/advanced/bullet.js
@@ -6,15 +6,15 @@
   };
 
   Bullet.prototype = {
-	  size: { x:1, y:1 },
+    size: { x:1, y:1 },
     speed: 1000,
     zIndex: 1,
 
     update: function() {
       if (this.game.state !== this.game.STATE.PLAYING) return;
 
-		  var mx = this.vel.x * this.game.coquette.updater.tick;
-		  var my = this.vel.y * this.game.coquette.updater.tick;
+      var mx = this.vel.x * this.game.coquette.updater.tick;
+      var my = this.vel.y * this.game.coquette.updater.tick;
       this.pos.x += mx;
       this.pos.y += my;
 

--- a/demos/advanced/game.js
+++ b/demos/advanced/game.js
@@ -28,7 +28,7 @@
       });
     },
 
-	  update: function() {
+    update: function() {
       if (this.state === this.STATE.PLAYING) {
         if (this.score() <= 0) {
           this.state = this.STATE.OVER;
@@ -52,9 +52,9 @@
           this.state = this.STATE.PLAYING;
         }
       }
-	  },
+    },
 
-	  draw: function() {
+    draw: function() {
       if (this.state === this.STATE.PLAYING) {
         for (var i = 0; i < this.maxScore; i++) {
           var rAngle = this.maths.degToRad(360 / this.maxScore * i);
@@ -74,7 +74,7 @@
                                                   this.coquette.renderer.width / 2 - 100,
                                                   this.coquette.renderer.height / 2 - 50);
       }
-	  },
+    },
 
     circle: function(pos, radius, color) {
       var ctx = this.coquette.renderer.getCtx();

--- a/demos/advanced/index.html
+++ b/demos/advanced/index.html
@@ -1,26 +1,26 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>Left Right Space</title>
-	<style type="text/css">
-		html,body {
-			background-color: #000;
-			color: #fff;
-			font-family: helvetica, arial, sans-serif;
-			margin: 0;
-			padding: 0;
-			font-size: 12pt;
-		}
+  <title>Left Right Space</title>
+  <style type="text/css">
+    html,body {
+      background-color: #000;
+      color: #fff;
+      font-family: helvetica, arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      font-size: 12pt;
+    }
 
-		#canvas {
-			position: absolute;
-			left: 0;
-			right: 0;
-			top: 0;
-			bottom: 0;
-			margin: auto;
-		}
-	</style>
+    #canvas {
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 0;
+      bottom: 0;
+      margin: auto;
+    }
+  </style>
 
   <script src="head.loader.js"></script>
   <script type="text/javascript">
@@ -38,6 +38,6 @@
   </script>
 </head>
 <body>
-	<canvas id="canvas"></canvas>
+  <canvas id="canvas"></canvas>
 </body>
 </html>

--- a/demos/advanced/player.js
+++ b/demos/advanced/player.js
@@ -25,11 +25,11 @@
     size: { x:1, y:1 },
     zIndex: 2,
 
-	  update: function() {
+    update: function() {
       if (this.game.state !== this.game.STATE.PLAYING) return;
       this.handleKeyboard();
       this.draw();
-	  },
+    },
 
     collision: function(other) {
       if (other instanceof Asteroid) {
@@ -105,15 +105,15 @@
     },
 
     handleKeyboard: function() {
-	    if(this.game.coquette.inputter.state(this.game.coquette.inputter.LEFT_ARROW)) {
+      if(this.game.coquette.inputter.state(this.game.coquette.inputter.LEFT_ARROW)) {
         this.move("left");
-	    }
+      }
 
       if(this.game.coquette.inputter.state(this.game.coquette.inputter.RIGHT_ARROW)) {
         this.move("right");
-	    }
+      }
 
-	    if(this.game.coquette.inputter.state(this.game.coquette.inputter.SPACE)) {
+      if(this.game.coquette.inputter.state(this.game.coquette.inputter.SPACE)) {
         this.shootBullet();
       }
     },


### PR DESCRIPTION
Fixes issue #3 for tabs left in advanced demo.

Note:
I left the third-party script head.loader.js untouched.
