### PR TITLE
Asteroid in Advanced Demo uses undocumented module runner

### DIFF
--- a/demos/advanced/asteroid.js
+++ b/demos/advanced/asteroid.js
@@ -65,7 +65,7 @@
       this.game.endClip(ctx);
     },
 
-    destroy: function(other) {
+    destroy: function() {
       for (var i = 0, len = this.collidingAsteroids.length; i < len; i++) {
         if (this.collidingAsteroids[i] !== undefined) {
           if (this.collidingAsteroids[i].destroyed === false) {
@@ -87,7 +87,7 @@
           if (this.collidingAsteroids.length === 0) {
             this.spawnTwin(other);
           } else if (this.collidingAsteroids.length > 0) {
-            this.destroy(other);
+            this.destroy();
           }
         } else if (other instanceof Player) {
           this.spawnTwin(other);


### PR DESCRIPTION
Since the Runner is not described in the README and is only used by the Entities module to plan entities creation and destruction at this point, it feels like coquette.runner is not part of the public API.

In this pull request, I propose to remove the reference to the runner from the demo. I saw no visible impact when calling the destroy() method of the asteroid immediately (which delays the destruction to the next tick anyway) instead of waiting one more tick before calling destroy() (and planning the actual destruction one tick later).

The alternative would be to make the runner explicitly part of the API by describing it in the README.

More generally, it is not really clear to me which parts of the publicly accessible properties and methods are fair game, and which ones should not be used because they could evolve or be removed in the future. I will open a separate issue about this concern.
