### PR TITLE
Line 9: change comma to semicolon

### DIFF
--- a/spec/renderer.spec.js
+++ b/spec/renderer.spec.js
@@ -6,7 +6,7 @@ var Runner = require('../src/runner').Runner;
 var MockContext = function() {
   this.translate = function() {};
   this.fillRect = function() {};
-  this.save = function() {},
+  this.save = function() {};
   this.restore = function() {}
 };
 


### PR DESCRIPTION
Function expression on line 9 ended with a comma instead of a semicolon--now fixed.

![before](https://cloud.githubusercontent.com/assets/3811225/4801050/81ef2d50-5e2c-11e4-8ffd-7f067f35f526.png)
![after](https://cloud.githubusercontent.com/assets/3811225/4801051/852995f0-5e2c-11e4-984b-beb279fa23b7.png)
